### PR TITLE
Added validator to "Choose license"

### DIFF
--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -234,7 +234,7 @@ const schema = {
               minItems: 1,
               validate: [
                 {
-                  type: 'required',
+                  type: "required",
                 },
               ],
               description:

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -231,6 +231,12 @@ const schema = {
 
               fieldKey: "field_array",
               title: "Choose License",
+              minItems: 1,
+              validate: [
+                {
+                  type: 'required',
+                },
+              ],
               description:
                 "DPGs must use an open license. Please identify which of these approved open licenses this project uses: *. For Open Source Software, we only accept OSI approved licenses. For Open Content we require the use of a Creative Commons license while we encourage projects to use a license which allows for both derivatives and commercial reuse or dedicate content to the public domain (CC0) we also accept licenses which do not allow for commercial reuse: CC-BY-NC and CC-BY-NC-SA. For data we require a Open Data Commons approved license listed at opendefinition.org/licenses/. IF YOU USE A LICENSE THAT IS NOT CURRENTLY LISTED HERE BUT YOU BELIEVE SHOULD BE INCLUDED PLEASE EMAIL nominations@digitalpublicgoods.net",
               RemoveButtonGridProps: {xs: 3},


### PR DESCRIPTION
Currently, in the first section of the submission form, the `Continue` button is enabled even if no license is added to the form. 
Since it is essential to provide a license while nominating DPGs, the `Continue` button should not be enabled until at least one license is added to the form. I have implemented this change by adding the `required` and `minItems` validators to the field `license`. This would make it a little more intuitive for the submitter to understand that the license field is required while filling the form.