### PR TITLE
Update dpgPath variable to remove obsolete screening keyword

### DIFF
--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -112,8 +112,8 @@ function getSubmissionFiles(values, nomineeJSON) {
   // Add nominee submission to nominee directory
   nomineePath = "nominees/" + `${name}`;
 
-  // Add DPG submission to screening directory
-  dpgPath = "screening/" + `${name}`;
+  // Add DPG submission to digitalpublicgoods directory
+  dpgPath = "digitalpublicgoods/" + `${name}`;
 
   stage === "nominee"
     ? (files = {


### PR DESCRIPTION
Update `dpgPath` variable to remove obsolete `screening` keyword. `digitalpublicgoods` replaces `screening` from now on.