### PR TITLE
DPG: Splitting nomination and full submission into two pull requests

### DIFF
--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -1,4 +1,4 @@
-import { Octokit } from "@octokit/core";
+import {Octokit} from "@octokit/core";
 import {
   createPullRequest,
   composeCreatePullRequest,
@@ -100,21 +100,21 @@ function getSubmissionFiles(values, nomineeJSON) {
   dpgPath = "digitalpublicgoods/" + `${name}`;
   stage === "nominee"
     ? (files = {
-      [nomineePath]: {
-        content: nomineeJSON,
-        encoding: "utf-8",
-      },
-    })
+        [nomineePath]: {
+          content: nomineeJSON,
+          encoding: "utf-8",
+        },
+      })
     : (files = {
-      [nomineePath]: {
-        content: nomineeJSON,
-        encoding: "utf-8",
-      },
-      [dpgPath]: {
-        content: data,
-        encoding: "utf-8",
-      },
-    });
+        [nomineePath]: {
+          content: nomineeJSON,
+          encoding: "utf-8",
+        },
+        [dpgPath]: {
+          content: data,
+          encoding: "utf-8",
+        },
+      });
   return files;
 }
 // Nominee processing before opening pull request
@@ -139,7 +139,6 @@ function nomineeSubmission(values, sortedSubmission) {
 }
 
 function submitPullRequests(projectName, filesObject) {
-
   const MyOctokit = Octokit.plugin(createPullRequest);
   const octokit = new MyOctokit({
     auth: TOKEN,
@@ -149,28 +148,28 @@ function submitPullRequests(projectName, filesObject) {
   let promiseArray = [];
 
   for (const submission in filesObject) {
-
-    let singleFile = {}
-    singleFile[submission.toString()] = filesObject[submission.toString()]
+    let singleFile = {};
+    singleFile[submission.toString()] = filesObject[submission.toString()];
 
     // Returns a normal Octokit PR response
     // See https://octokit.github.io/rest.js/#octokit-routes-pulls-create
-    promiseArray.push(composeCreatePullRequest(octokit, {
-      owner: GITHUB_OWNER,
-      repo: GITHUB_REPO,
-      title: `Add nominee: ${projectName}`,
-      body:
-        "Automatic addition of a new nominee submitted through the online form available at https://digitalpublicgoods.net/submission",
-      base: GITHUB_BRANCH,
-      head: createGithubCheckoutBranch(projectName),
-      changes: [
-        {
-          // optional: if `files` is not passed, an empty commit is created instead 
-          files: singleFile,
-          commit: `BLD: Add ${projectName}`,
-        },
-      ],
-    })
+    promiseArray.push(
+      composeCreatePullRequest(octokit, {
+        owner: GITHUB_OWNER,
+        repo: GITHUB_REPO,
+        title: `Add nominee: ${projectName}`,
+        body:
+          "Automatic addition of a new nominee submitted through the online form available at https://digitalpublicgoods.net/submission",
+        base: GITHUB_BRANCH,
+        head: createGithubCheckoutBranch(projectName),
+        changes: [
+          {
+            // optional: if `files` is not passed, an empty commit is created instead
+            files: singleFile,
+            commit: `BLD: Add ${projectName}`,
+          },
+        ],
+      })
     );
   }
   // return the array of promises
@@ -192,12 +191,9 @@ export default async (req, res) => {
     nomineeJSON = JSON.stringify(sortedSubmission, null, 2).concat("\n");
 
     let result = await Promise.allSettled(
-      submitPullRequests(
-        getProjectName(values),
-        getSubmissionFiles(values, nomineeJSON)
-      )
-    ).then(results => {
-      console.log('The final result ', results)
+      submitPullRequests(getProjectName(values), getSubmissionFiles(values, nomineeJSON))
+    ).then((results) => {
+      console.log("The final result ", results);
       // There's the opportunity to check if any of them failed but that's for another PR
       let finalResult = results[0].value;
       finalResult.number = results[0].value.data.number;

--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -1,9 +1,8 @@
-import {Octokit} from "@octokit/core";
+import { Octokit } from "@octokit/core";
 import {
   createPullRequest,
   composeCreatePullRequest,
 } from "octokit-plugin-create-pull-request";
-
 const TOKEN = process.env.ACCESS_TOKEN; // create token at https://github.com/settings/tokens/new?scopes=repo
 const GITHUB_OWNER = process.env.NEXT_PUBLIC_GITHUB_OWNER
   ? process.env.NEXT_PUBLIC_GITHUB_OWNER
@@ -14,12 +13,10 @@ const GITHUB_REPO = process.env.NEXT_PUBLIC_GITHUB_REPO
 const GITHUB_BRANCH = process.env.GITHUB_BRANCH
   ? process.env.GITHUB_BRANCH
   : "main"; /* optional: defaults to default branch */
-
 // Return Project name
 function getProjectName(values) {
   return values.name;
 }
-
 // Parse name of project prior to saving file
 function parseProjectName(values) {
   return (
@@ -30,7 +27,6 @@ function parseProjectName(values) {
       .replace(/ /g, "-") + ".json"
   );
 }
-
 // Create Github checkout branch for current submissions
 function createGithubCheckoutBranch(name) {
   const checkoutBranch =
@@ -39,24 +35,20 @@ function createGithubCheckoutBranch(name) {
     (Math.random() * 10 ** 16).toString(36);
   return checkoutBranch;
 }
-
 // Get SDG relevance info
 function getSDGRelevanceInfo(values, sdgNumber, evidenceText) {
   //Loop through SDG array and parse SDG information
   for (let i = 0; i < values.SDGs.length; i++) {
     sdgNumber = parseInt(values.SDGs[i]);
     evidenceText = "evidenceText".concat(sdgNumber);
-
     values.SDGs[i] = {
       SDGNumber: sdgNumber,
       evidenceText: values[evidenceText],
     };
-
     delete values[evidenceText];
   }
   return values;
 }
-
 // Order fields e.g organizations
 function orderFields(values) {
   let name, website, org_type, contact_name, contact_email;
@@ -67,7 +59,6 @@ function orderFields(values) {
     org_type = values.organizations[i].org_type;
     contact_name = values.organizations[i].contact_name;
     contact_email = values.organizations[i].contact_email;
-
     values.organizations[i] = {
       name: name,
       website: website,
@@ -78,7 +69,6 @@ function orderFields(values) {
   }
   return values;
 }
-
 // Return multiple submission files including corresponding filepaths
 function getSubmissionFiles(values, nomineeJSON) {
   let name,
@@ -87,9 +77,7 @@ function getSubmissionFiles(values, nomineeJSON) {
     stage,
     data,
     files = {};
-
   stage = values.stage;
-
   // Delete multiple DPG nomination fields
   [
     "aliases",
@@ -102,40 +90,33 @@ function getSubmissionFiles(values, nomineeJSON) {
     "stage",
     "repositoryURL",
   ].forEach((e) => delete values[e]);
-
   // Convert JavaScript submission sorted object into JSON string and add newline at EOF
   data = JSON.stringify(values, null, 2).concat("\n");
-
   // Parse project names using DPG naming convention for filenames
   name = parseProjectName(values);
-
   // Add nominee submission to nominee directory
   nomineePath = "nominees/" + `${name}`;
-
   // Add DPG submission to digitalpublicgoods directory
   dpgPath = "digitalpublicgoods/" + `${name}`;
-
   stage === "nominee"
     ? (files = {
-        [nomineePath]: {
-          content: nomineeJSON,
-          encoding: "utf-8",
-        },
-      })
+      [nomineePath]: {
+        content: nomineeJSON,
+        encoding: "utf-8",
+      },
+    })
     : (files = {
-        [nomineePath]: {
-          content: nomineeJSON,
-          encoding: "utf-8",
-        },
-        [dpgPath]: {
-          content: data,
-          encoding: "utf-8",
-        },
-      });
-
+      [nomineePath]: {
+        content: nomineeJSON,
+        encoding: "utf-8",
+      },
+      [dpgPath]: {
+        content: data,
+        encoding: "utf-8",
+      },
+    });
   return files;
 }
-
 // Nominee processing before opening pull request
 function nomineeSubmission(values, sortedSubmission) {
   // Sort entries
@@ -152,36 +133,78 @@ function nomineeSubmission(values, sortedSubmission) {
     organizations: values.organizations ? [values.organizations] : [],
     stage: values.stage ? values.stage : "",
   };
-
   // Order nominee fields in the correct order e.g organizations
   sortedSubmission = orderFields(sortedSubmission);
   return sortedSubmission;
 }
-
+function submitPullRequests(projectName, filesObject) {
+  // console.log('the raw files ',files)
+  const MyOctokit = Octokit.plugin(createPullRequest);
+  const octokit = new MyOctokit({
+    auth: TOKEN,
+  });
+  // initialize an array of Promises
+  let promiseArray = [];
+  // let fileKeys = Object.keys(files)
+  for (const submission in filesObject) {
+    // if (Object.hasOwnProperty.call(files, submission)) {
+    const file = filesObject[submission.toString()];
+    let singleFile = {}
+    singleFile[submission.toString()] = filesObject[submission.toString()]
+    // console.log("The single file ",singleFile)
+    // Returns a normal Octokit PR response
+    // See https://octokit.github.io/rest.js/#octokit-routes-pulls-create
+    promiseArray.push(composeCreatePullRequest(octokit, {
+      owner: GITHUB_OWNER,
+      repo: GITHUB_REPO,
+      title: `Add nominee: ${projectName}`,
+      body:
+        "Automatic addition of a new nominee submitted through the online form available at https://digitalpublicgoods.net/submission",
+      base: GITHUB_BRANCH,
+      head: createGithubCheckoutBranch(projectName),
+      changes: [
+        {
+          // optional: if `files` is not passed, an empty commit is created instead 
+          files: singleFile,
+          commit: `BLD: Add ${projectName}`,
+        },
+      ],
+    })
+    );
+    // }
+  }
+  // return the array of promises
+  return promiseArray;
+}
 export default async (req, res) => {
   if (req.method === "POST") {
     let values = req.body.values;
-
     let nomineeJSON, sdgNumber, evidenceText, sortedSubmission;
-
     // Exclude contact information from pull request
     delete values["contact"];
-
     // Parse SDG information
     values = getSDGRelevanceInfo(values, sdgNumber, evidenceText);
-
     sortedSubmission = nomineeSubmission(values, sortedSubmission);
-
     // Convert JavaScript submission sorted object into JSON string and add newline at EOF
     nomineeJSON = JSON.stringify(sortedSubmission, null, 2).concat("\n");
-
+    let result = await Promise.allSettled(
+      submitPullRequests(
+        getProjectName(values),
+        getSubmissionFiles(values, nomineeJSON)
+      )
+    ).then(results => {
+      console.log('The final result ', results)
+      // There's the opportunity to check if any of them failed but that's for another PR
+      let finalResult = results[0].value;
+      finalResult.number = results[0].value.data.number;
+      return finalResult;
+    });
+/* 
+    let result;
     const MyOctokit = Octokit.plugin(createPullRequest);
-
     const octokit = new MyOctokit({
       auth: TOKEN,
     });
-
-    let result;
     try {
       // Returns a normal Octokit PR response
       // See https://octokit.github.io/rest.js/#octokit-routes-pulls-create
@@ -195,20 +218,19 @@ export default async (req, res) => {
         head: createGithubCheckoutBranch(parseProjectName(values)),
         changes: [
           {
-            /* optional: if `files` is not passed, an empty commit is created instead */
+            // optional: if `files` is not passed, an empty commit is created instead 
             files: getSubmissionFiles(values, nomineeJSON),
             commit: `BLD: Add ${getProjectName(values)}`,
           },
         ],
       });
-
       result = {
         number: response.data.number,
       };
     } catch (err) {
-      result = {error: err.message || err.toString()};
+      result = { error: err.message || err.toString() };
     }
-
+ */
     // return an unconditional success response
     res.statusCode = 200;
     res.setHeader("Content-Type", "application/json");

--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -157,7 +157,9 @@ function submitPullRequests(projectName, filesObject) {
       composeCreatePullRequest(octokit, {
         owner: GITHUB_OWNER,
         repo: GITHUB_REPO,
-        title: `Add nominee: ${projectName}`,
+        title: submission.toString().includes("nominees")
+          ? `Add nominee: ${projectName}`
+          : `Add DPG: ${projectName}`,
         body:
           "Automatic addition of a new nominee submitted through the online form available at https://digitalpublicgoods.net/submission",
         base: GITHUB_BRANCH,


### PR DESCRIPTION
I had to extract the original `try-catch` sequence that sent the single Pull Request into its own function to return an array of Promises (more on that later),

Then I split the original file object within a `for-in` loop that sends each half as a Pull Request, and adds it to the array of Promises.
Finally, I get the results of all the Pull Requests using `Promise.allSettled()` and go on my merry way.

_**PS**: There's the opportunity to check if any of them failed but that's for another PR since the current setup is tied with the frontend. So for now, I'm only returning the result of the first PR (which was originally the case) in order for the frontend to continue its work._