### PR TITLE
BUG: fix #42

### DIFF
--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -45,16 +45,29 @@ function createGithubCheckoutBranch(name) {
   return checkoutBranch;
 }
 // Get SDG relevance info
-function getSDGRelevanceInfo(values, sdgNumber, evidenceText) {
+function getSDGRelevanceInfo(values) {
   //Loop through SDG array and parse SDG information
   for (let i = 0; i < values.SDGs.length; i++) {
-    sdgNumber = parseInt(values.SDGs[i]);
-    evidenceText = "evidenceText".concat(sdgNumber);
+    let sdgNumber = parseInt(values.SDGs[i]);
+    let evidenceText = "evidenceText".concat(sdgNumber);
+    let evidenceURL = "evidenceURL".concat(sdgNumber);
+
+    // Initialize the object in the array where it exists
     values.SDGs[i] = {
       SDGNumber: sdgNumber,
-      evidenceText: values[evidenceText],
     };
-    delete values[evidenceText];
+
+    // Only add the field, if there exists a value for it
+    if (values[evidenceText]) {
+      values.SDGs[i].evidenceText = values[evidenceText];
+      delete values[evidenceText];
+    }
+
+    // Only add the field, if there exists a value for it
+    if (values[evidenceURL]) {
+      values.SDGs[i].evidenceURL = values[evidenceURL];
+      delete values[evidenceURL];
+    }
   }
   return values;
 }
@@ -191,13 +204,13 @@ function submitPullRequests(projectName, filesObject) {
 export default async (req, res) => {
   if (req.method === "POST") {
     let values = req.body.values;
-    let nomineeJSON, sdgNumber, evidenceText, sortedSubmission;
+    let nomineeJSON, sortedSubmission;
 
     // Exclude contact information from pull request
     delete values["contact"];
 
     // Parse SDG information
-    values = getSDGRelevanceInfo(values, sdgNumber, evidenceText);
+    values = getSDGRelevanceInfo(values);
     sortedSubmission = nomineeSubmission(values, sortedSubmission);
     // Convert JavaScript submission sorted object into JSON string and add newline at EOF
     nomineeJSON = JSON.stringify(sortedSubmission, null, 2).concat("\n");


### PR DESCRIPTION
Fixes #42.

For a submission that included relevance to SDGs 1, 2 and 3 with the following fields:

```
  "SDGs": [
    {
      "SDGNumber": 1,
      "evidenceText": "description1",
      "evidenceURL": "http://example.com/1"
    },
    {
      "SDGNumber": 2,
      "evidenceText": "description2"
    },
    {
      "SDGNumber": 3,
      "evidenceURL": "http://example.com/3"
    }
```

The old code generate this faulty PR: lacabra/publicgoods-candidates#10 (which was running an older version of master before the PR submission was split into two), after this fix, these are two valid PRs:
* lacabra/publicgoods-candidates/pull/15
* lacabra/publicgoods-candidates/pull/16

