### PR TITLE
FIX: formOptions.onCancel is not a function

### DIFF
--- a/pages/form.js
+++ b/pages/form.js
@@ -188,6 +188,12 @@ export default function Home() {
     return errors;
   };
 
+  const onCancel = () => {
+    router.push({
+      pathname: "/",
+    });
+  };
+
   return (
     <Container component="main" maxWidth="sm">
       <Head>
@@ -225,6 +231,7 @@ export default function Home() {
               componentMapper={componentMapper}
               validatorMapper={validatorMapper} // not required
               initialValues={initialValues}
+              onCancel={onCancel}
             />
           </ThemeProvider>
         </div>


### PR DESCRIPTION
# Issue

https://github.com/lacabra/submission-digitalpublicgoods/issues/22

## Fix #22 

Adding an ```onCancel``` prop fixes the error. 

The onCancel function will send the user back to the home page of the form as well as clear the form due to unmounting. 