### PR TITLE
BUG: fix CORS by adding vercel.conf

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        {"key": "Access-Control-Allow-Credentials", "value": "true"},
+        {"key": "Access-Control-Allow-Origin", "value": "https://digitalpublicgoods.net"},
+        {"key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS,POST"},
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Vercel deployment environment does not seem to pick up `nextjs.conf.js`, so trying an alternative through `vercel.conf`

Continues the work started in #49