### PR TITLE
BUG: hardcode nominee stage for all nominees

### DIFF
--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -142,6 +142,7 @@ function getSubmissionFiles(values, nomineeJSON) {
 // Nominee processing before opening pull request
 function nomineeSubmission(values, sortedSubmission) {
   // Sort entries
+  // Note that "stage": "nominee" for all nominations
   sortedSubmission = {
     name: values.name ? values.name : "",
     aliases: values.aliases ? [values.aliases] : [""],
@@ -153,7 +154,7 @@ function nomineeSubmission(values, sortedSubmission) {
     type: values.type ? values.type : [],
     repositoryURL: values.repositoryURL ? values.repositoryURL : "",
     organizations: values.organizations ? [values.organizations] : [],
-    stage: values.stage ? values.stage : "",
+    stage: "nominee",
   };
   // Order nominee fields in the correct order e.g organizations
   sortedSubmission = orderFields(sortedSubmission);


### PR DESCRIPTION
Fix #53 

* Hardcodes `"stage": "nominee"` for the nomination PR, even when making a full DPG submission because at that stage it is still a nominee (that field will be manually updated once the full submission is reviewed and approved)

This has been tested locally against this test repository, and you can see the results below:
* https://github.com/lacabra/publicgoods-candidates/pull/21
* https://github.com/lacabra/publicgoods-candidates/pull/20

Specifically [this line](https://github.com/lacabra/publicgoods-candidates/pull/21/files#diff-ed7fcf50ce8e6119e3b7f3a723b5e76ef6e822b1c68eb3410383fea6f7b7f54aR32)