### PR TITLE
BUG: fix #62

### DIFF
--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -19,13 +19,13 @@ function getProjectName(values) {
 }
 // Parse name of project prior to saving file
 function parseProjectName(values) {
-  return (
-    values.name
-      .normalize("NFD")
-      .toLowerCase()
-      .replace(/[\u0300-\u036f]/g, "")
-      .replace(/ /g, "-") + ".json"
-  );
+  return values.name
+    .normalize("NFD") // NFD normalization separates vowels from accents, to be removed later
+    .toLowerCase()
+    .replace(/\s{2,}/g, " ") // replace multiple consecutive whitespaces with a single whitespace
+    .replace(/ /g, "-") // replace whitespace with dash
+    .replace(/[^A-Za-z0-9-.]/g, "") // remove anything else other than A-Za-z0-9-. (note the inclusion of '-' and '.')
+    .replace(/-{2,}/g, "-"); // replace multiple consecutive dashes with a single dash
 }
 // Create Github checkout branch for current submissions
 function createGithubCheckoutBranch(name) {


### PR DESCRIPTION
Fixes #62 by aiming for the most generic case of removing any non-alphanumeric characters (negation of `A-Za-z0-9`) and replacing whitespace by dash, and removing any consecutive dashes.

Complementary to unicef/publicgoods-nominees#720