### PR TITLE
Bug removing nulls from submission

### DIFF
--- a/pages/form.js
+++ b/pages/form.js
@@ -125,7 +125,7 @@ export default function Home() {
   );
 
   async function saveToDb(values) {
-    removeNullsInArrays(values);
+    values = removeNullsInArrays(values);
     if (cookies.uuid) {
       await fetch(`/api/saveDB/${cookies.uuid}`, {
         method: "POST",
@@ -153,6 +153,7 @@ export default function Home() {
         }
       }
     });
+    return submission;
   }
 
   function checkNull(arrayItem) {


### PR DESCRIPTION
This PR fixes #61 

Just to double down on the `values` object being submitted, I'm reinitializing it after going through the recursive function `removeNullsInArrays`.
I know `removeNullsInArrays` mutates the array however I'm now returning the same object from the function and replacing it with its caller `values` once again after testing `removeNullsInArrays`.