### PR TITLE
BUG: remove leading whitespace from name

### DIFF
--- a/pages/api/openPR.js
+++ b/pages/api/openPR.js
@@ -13,13 +13,11 @@ const GITHUB_REPO = process.env.NEXT_PUBLIC_GITHUB_REPO
 const GITHUB_BRANCH = process.env.GITHUB_BRANCH
   ? process.env.GITHUB_BRANCH
   : "main"; /* optional: defaults to default branch */
-// Return Project name
-function getProjectName(values) {
-  return values.name;
-}
+
 // Parse name of project prior to saving file
 function parseProjectName(values) {
   return values.name
+    .trim() // removes whitespace from both ends of a string
     .normalize("NFD") // NFD normalization separates vowels from accents, to be removed later
     .toLowerCase()
     .replace(/\s{2,}/g, " ") // replace multiple consecutive whitespaces with a single whitespace
@@ -217,7 +215,10 @@ export default async (req, res) => {
     nomineeJSON = JSON.stringify(sortedSubmission, null, 2).concat("\n");
 
     let result = await Promise.allSettled(
-      submitPullRequests(getProjectName(values), getSubmissionFiles(values, nomineeJSON))
+      submitPullRequests(
+        parseProjectName(values),
+        getSubmissionFiles(values, nomineeJSON)
+      )
     ).then((results) => {
       let pullRequestNumbers = [];
 


### PR DESCRIPTION
Leading whitespace in a project name causes the CI to fail for form submissions, like in [this run](https://github.com/unicef/publicgoods-candidates/runs/3853990269) from unicef/publicgoods-candidates#740

Changes in this PR prevent this from happening this again by parsing the name and applying the function `trim()` to remove any leading (and trailing) whitespace. The function that creates the branchname, now gets the name from `parseProjectName()`, and the function `getProjectName()` becomes obsolete and has been deleted.
