### PR TITLE
Update schema.js

### DIFF
--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -115,7 +115,7 @@ const schema = {
                 },
                 {
                   label: "Open Artificial Intelligence (AI) Model",
-                  value: "model",
+                  value: "aimodel",
                 },
                 {
                   label: "Open Standard",


### PR DESCRIPTION
Fix schema mismatch: `model` should be [aimodel](https://github.com/unicef/publicgoods-candidates/blob/b9a7f452c69ee836b7490826e51147266fe3529f/nominee-schema.json#L333)

This is the reason [this build failed](https://github.com/unicef/publicgoods-candidates/runs/4013054032?check_suite_focus=true).