### PR TITLE
PATCH: JSON schema for doNoHarm and others 

### DIFF
--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -1417,7 +1417,7 @@ const schema = {
               ],
             },
             {
-              name: "preventHarm[additionalInfoMechanismProcessesPolicies]",
+              name: "doNoHarm[preventHarm[additionalInfoMechanismProcessesPolicies]]",
               component: "text-field",
               label: "Additional risks and mitigation steps",
               description:
@@ -1777,7 +1777,8 @@ const schema = {
             },
             {
               component: "radio",
-              name: "protectionFromHarassment[addressSafetySecurityUnderageUsers]",
+              name:
+                "doNoHarm[protectionFromHarassment[addressSafetySecurityUnderageUsers]]",
               label:
                 "If yes - does the project take steps to address the safety and security of underage users?",
               description: "",
@@ -1796,7 +1797,7 @@ const schema = {
                 },
               ],
               condition: {
-                when: "protectionFromHarassment[userInteraction]",
+                when: "doNoHarm[protectionFromHarassment[userInteraction]]",
                 pattern: /Yes/,
               },
               isRequired: true,
@@ -1808,14 +1809,14 @@ const schema = {
             },
             {
               name:
-                "protectionFromHarassment[stepsAddressRiskPreventSafetyUnderageUsers]",
+                "doNoHarm[protectionFromHarassment[stepsAddressRiskPreventSafetyUnderageUsers]]",
               component: "field-array",
               label: "Steps to address risk",
               description:
                 "If yes - please describe the steps this project takes to address risk or prevent access by underage users:",
               helperText: "",
               condition: {
-                when: "protectionFromHarassment[userInteraction]",
+                when: "doNoHarm[protectionFromHarassment[userInteraction]]",
                 pattern: /Yes/,
               },
               isRequired: true,
@@ -1833,7 +1834,7 @@ const schema = {
             },
             {
               component: "radio",
-              name: "protectionFromHarassment[griefAbuseHarassmentProtection]",
+              name: "doNoHarm[protectionFromHarassment[griefAbuseHarassmentProtection]]",
               label:
                 "If yes - does the project help users and contributors protect themselves against grief, abuse, and harassment.",
               description: "",
@@ -1852,7 +1853,7 @@ const schema = {
                 },
               ],
               condition: {
-                when: "protectionFromHarassment[userInteraction]",
+                when: "doNoHarm[protectionFromHarassment[userInteraction]]",
                 pattern: /Yes/,
               },
               isRequired: true,
@@ -1863,14 +1864,14 @@ const schema = {
               ],
             },
             {
-              name: "protectionFromHarassment[harassmentProtectionSteps]",
+              name: "doNoHarm[protectionFromHarassment[harassmentProtectionSteps]]",
               component: "field-array",
               label: "Steps to address risk",
               description:
                 "If yes - please describe the steps taken to help users protect themselves.",
               helperText: "",
               condition: {
-                when: "protectionFromHarassment[userInteraction]",
+                when: "doNoHarm[protectionFromHarassment[userInteraction]]",
                 pattern: /Yes/,
               },
               isRequired: true,


### PR DESCRIPTION
This PR fixes #65 

- It patches a number of misarranged keys and conditions in the schema.
- I noticed that a number of the manual changes that were made to fix  PR [#703](https://github.com/unicef/publicgoods-candidates/pull/703) centred around the `doNoHarm` section of the schema.
- I used a diff tool and compared the breaking build commit [be72b97](https://github.com/unicef/publicgoods-candidates/pull/703/commits/be72b9745c91b8824aae30cf4e7bd5d992a8f8fb) with the manual fix of [26dec24](https://github.com/unicef/publicgoods-candidates/pull/703/commits/26dec24d3564eee2ef29f5be720733e4928d6856)
- A number of the sub-conditions for the form for the `doNoHarm` section too were missing their root keys which would not make them show and as such, their JSON keys would not be added to the final submission.
- It was a lot of eyeballing and it is possible that I may have missed 1 or 2 but I believe I have addressed most of them