### PR TITLE
BUGFIX: included missing import of conditional submit flag

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "Launch Program",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/pages/form.js"
+    }
+  ]
+}

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -1,5 +1,3 @@
-import {CONDITIONAL_SUBMIT_FLAG as wizard} from "@data-driven-forms/common/wizard/";
-
 const schema = {
   title: "Digital Public Goods Submission",
   description: `This is a BETA version of our submission form and process which means we'll be learning from it and may contact you for follow-up information and input on the process as well as your project submission.`,
@@ -7,6 +5,7 @@ const schema = {
     {
       component: "wizard",
       name: "wizard",
+      conditionalSubmitFlag: "nominee-final-step",
       fields: [
         {
           title: "Get started with submission wizard form",
@@ -14,7 +13,7 @@ const schema = {
           nextStep: {
             when: "stage",
             stepMapper: {
-              nominee: wizard.CONDITIONAL_SUBMIT_FLAG,
+              nominee: "nominee-final-step",
               DPG: "clearOwnership",
             },
           },

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -1,4 +1,4 @@
-import {CONDITIONAL_SUBMIT_FLAG as wizard} from "@data-driven-forms/common/wizard";
+import {CONDITIONAL_SUBMIT_FLAG as wizard} from "@data-driven-forms/common/wizard/";
 
 const schema = {
   title: "Digital Public Goods Submission",

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -1,4 +1,4 @@
-import wizard from "@data-driven-forms/common/wizard/index.js";
+import {CONDITIONAL_SUBMIT_FLAG} from "@data-driven-forms/common/wizard";
 
 const schema = {
   title: "Digital Public Goods Submission",
@@ -14,7 +14,7 @@ const schema = {
           nextStep: {
             when: "stage",
             stepMapper: {
-              nominee: wizard.CONDITIONAL_SUBMIT_FLAG,
+              nominee: CONDITIONAL_SUBMIT_FLAG,
               DPG: "clearOwnership",
             },
           },

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -1,4 +1,4 @@
-import {CONDITIONAL_SUBMIT_FLAG} from "@data-driven-forms/common/wizard";
+import {CONDITIONAL_SUBMIT_FLAG as wizard} from "@data-driven-forms/common/wizard";
 
 const schema = {
   title: "Digital Public Goods Submission",
@@ -14,7 +14,7 @@ const schema = {
           nextStep: {
             when: "stage",
             stepMapper: {
-              nominee: CONDITIONAL_SUBMIT_FLAG,
+              nominee: wizard.CONDITIONAL_SUBMIT_FLAG,
               DPG: "clearOwnership",
             },
           },

--- a/scripts/validate-schema.js
+++ b/scripts/validate-schema.js
@@ -23,7 +23,7 @@ var data = fs.readFileSync(SUBMISSION_SCHEMA, "utf8", function (err) {
 });
 var result = data
   .replace(
-    /import wizard from "@data-driven-forms\/common\/wizard\/index.js"/,
+    /import {CONDITIONAL_SUBMIT_FLAG as wizard} from "@data-driven-forms\/common\/wizard\/"/,
     "const wizard = {CONDITIONAL_SUBMIT_FLAG: true}"
   )
   .replace(/export default schema/, "exports.schema = schema");

--- a/scripts/validate-schema.js
+++ b/scripts/validate-schema.js
@@ -21,12 +21,7 @@ var data = fs.readFileSync(SUBMISSION_SCHEMA, "utf8", function (err) {
     return console.log(err);
   }
 });
-var result = data
-  .replace(
-    /import {CONDITIONAL_SUBMIT_FLAG as wizard} from "@data-driven-forms\/common\/wizard\/"/,
-    "const wizard = {CONDITIONAL_SUBMIT_FLAG: true}"
-  )
-  .replace(/export default schema/, "exports.schema = schema");
+var result = data.replace(/export default schema/, "exports.schema = schema");
 fs.writeFileSync(path.join(__dirname, "./schema.js"), result, "utf8", function (err) {
   if (err) {
     console.log("An error occured while writing file 'schema.js'");


### PR DESCRIPTION
This PR fixes #75 

According to the data-driven-forms docs, the `submit` flag needed an import which I've included https://data-driven-forms.org/provided-mappers/wizard?mapper=suir#heading-nextstep

### Root Cause:
The initial import there seems to be broken probably because that was not how that import was supposed to be done or could be because of a package update or improvement.
