### PR TITLE
BUG: fix missing doc section

### DIFF
--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -971,7 +971,7 @@ const schema = {
         {
           title: "Indicator 4 - Platform Independence",
           name: "platformIndependence",
-          nextStep: "privacy",
+          nextStep: "documentation",
           component: "sub-form",
           fields: [
             {

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -1053,7 +1053,7 @@ const schema = {
         {
           title: "Indicator 5 - Documentation",
           name: "documentation",
-          nextStep: "nonPII",
+          nextStep: "NonPII",
           component: "sub-form",
           fields: [
             {


### PR DESCRIPTION
Fix missing documentation section in submission form. The fix is trivial, the section already existed, but it was skipped, so now the previous sections points to it.

Also fix #83 

This has been tested, with the output of the tests being here:
https://github.com/lacabra/publicgoods-candidates/pull/3
https://github.com/lacabra/publicgoods-candidates/pull/4