### PR TITLE
BUGFIX: Regex standard

### DIFF
--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -89,7 +89,7 @@ const schema = {
                 {
                   type: "pattern",
                   pattern: "^[a-z0-9._%+-]+@([a-z0-9.-]+.)+[a-z0-9.-]{2,4}$",
-                  message: "This may not be a valid email",
+                  message: "This may not be a valid email format",
                 },
               ],
             },

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -88,8 +88,8 @@ const schema = {
                 },
                 {
                   type: "pattern",
-                  pattern: "^[w-.]+@([w-]+.)+[w-]{2,4}$",
-                  message: "Not valid email",
+                  pattern: "^[a-z0-9._%+-]+@([a-z0-9.-]+.)+[a-z0-9.-]{2,4}$",
+                  message: "This may not be a valid email",
                 },
               ],
             },


### PR DESCRIPTION
The regex format used in #89 had to be rolled back to a much earlier standard as it was breaking in production.
the expression `[w-]` which encompasses alphanumeric characters was replaced with the older `[a-z0-9.-]` which is more expressive